### PR TITLE
Fixed webcam not stopping on unload

### DIFF
--- a/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamStream.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamStream.java
@@ -11,7 +11,8 @@ public class WebcamStream extends JavaScriptObject {
     // @formatter:off
     
     public final native void stop() /*-{
-        this.stop();
+        this.getVideoTracks()[0].stop();
+		this.getAudioTracks()[0].stop();
     }-*/;
     
     // @formatter:on


### PR DESCRIPTION
Moved from deprecated .stop() to
getVideoTracks()[0].stop();
getAudioTracks()[0].stop();
