### PR TITLE
Update how streams are stopped and allow clients to stop streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 webcam/target
 webcam-demo/target
 webcam-demo/src/main/webapp/VAADIN/widgetsets
+
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Webcam Add-on for Vaadin 7
+# Webcam Add-on for Vaadin 8
 
-Webcam is an HTML5 webcam component for Vaadin 7.
+Webcam is an HTML5 webcam component for Vaadin 8.
 
 ## Online demo
 
@@ -14,10 +14,10 @@ Official releases of this add-on will later be available at Vaadin Directory. Fo
 
 ## Building and running demo
 
-- git clone https://github.com/tehapo/webcam.git
-- mvn clean install
-- cd demo
-- mvn jetty:run
+- `git clone https://github.com/tehapo/webcam.git`
+- `mvn clean install`
+- `cd webcam-demo`
+- `mvn jetty:run`
 
 To see the demo, navigate to http://localhost:8080/
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam-root</artifactId>
 	<packaging>pom</packaging>
-	<version>0.3.0</version>
+	<version>0.3.1-SNAPSHOT</version>
 	<name>Webcam Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam-root</artifactId>
 	<packaging>pom</packaging>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.3.2-SNAPSHOT</version>
 	<name>Webcam Add-on Root Project</name>
 
 	<modules>

--- a/webcam-demo/pom.xml
+++ b/webcam-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam-demo</artifactId>
 	<packaging>war</packaging>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.3.2-SNAPSHOT</version>
 	<name>Webcam Add-on Demo</name>
 
 	<properties>

--- a/webcam-demo/pom.xml
+++ b/webcam-demo/pom.xml
@@ -5,12 +5,12 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam-demo</artifactId>
 	<packaging>war</packaging>
-	<version>0.3.0</version>
+	<version>0.3.1-SNAPSHOT</version>
 	<name>Webcam Add-on Demo</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.0.7</vaadin.version>
+		<vaadin.version>8.0.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
   

--- a/webcam-demo/src/main/webapp/VAADIN/themes/demo/styles.scss
+++ b/webcam-demo/src/main/webapp/VAADIN/themes/demo/styles.scss
@@ -1,4 +1,4 @@
-@import "../reindeer/reindeer.scss";
+@import "../valo/valo.scss";
 
 $blue: #00b4f0;
 $gray: #d1d1cf;
@@ -35,8 +35,8 @@ $darkgreen: darken($green, 30%);
 // Prefix all selectors in your theme with .demo
 .demo {
 
-    // Include reindeer theme styles in your theme
-    @include reindeer;
+    // Include valo theme styles in your theme
+    @include valo;
 
     // You can style your demo app right here
     .demoContentLayout {

--- a/webcam/pom.xml
+++ b/webcam/pom.xml
@@ -5,12 +5,12 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam</artifactId>
 	<packaging>jar</packaging>
-	<version>0.3.0</version>
+	<version>0.3.1-SNAPSHOT</version>
 	<name>Webcam</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.0.7</vaadin.version>
+		<vaadin.version>8.0.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->

--- a/webcam/pom.xml
+++ b/webcam/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.teemu</groupId>
 	<artifactId>webcam</artifactId>
 	<packaging>jar</packaging>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.3.2-SNAPSHOT</version>
 	<name>Webcam</name>
 
 	<properties>

--- a/webcam/src/main/java/org/vaadin/teemu/webcam/Webcam.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/Webcam.java
@@ -75,6 +75,10 @@ public class Webcam extends AbstractComponent {
         getRpcProxy(WebcamClientRpc.class).capture();
     }
 
+    public void stopStream() {
+        getRpcProxy(WebcamClientRpc.class).stopStream();
+    }
+
     protected OutputStream getOutputStream(String filename, String mimeType) {
         if (receiver != null) {
             return receiver.receiveUpload(filename, mimeType);

--- a/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamClientRpc.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamClientRpc.java
@@ -9,4 +9,9 @@ public interface WebcamClientRpc extends ClientRpc {
      */
     public void capture();
 
+    /**
+     * Passes the command to stop all tracks on the camera stream
+     */
+    public void stopStream();
+
 }

--- a/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamConnector.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamConnector.java
@@ -37,6 +37,11 @@ public class WebcamConnector extends AbstractComponentConnector {
                 // Commanded by the server-side component.
                 captureNow();
             }
+
+            @Override
+            public void stopStream() {
+                getWidget().stopSteam();
+            }
         });
     }
 

--- a/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamStream.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamStream.java
@@ -11,7 +11,12 @@ public class WebcamStream extends JavaScriptObject {
     // @formatter:off
     
     public final native void stop() /*-{
-        this.stop();
+        for (var i = 0; i < this.getTracks().length; i++) {
+            var track = this.getTracks()[i];
+            if(track !== null) {
+                track.stop();
+            }
+        }
     }-*/;
     
     // @formatter:on

--- a/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamWidget.java
+++ b/webcam/src/main/java/org/vaadin/teemu/webcam/client/WebcamWidget.java
@@ -45,6 +45,13 @@ public class WebcamWidget extends Widget {
         return video.getElement();
     }
 
+
+    protected void stopSteam() {
+        if (stream != null) {
+            stream.stop();
+        }
+    }
+
     public void setClickListener(EventListener listener) {
         if (video != null) {
             DOM.setEventListener(video.getElement(), listener);
@@ -54,9 +61,7 @@ public class WebcamWidget extends Widget {
     @Override
     protected void onUnload() {
         super.onUnload();
-        if (stream != null) {
-            stream.stop();
-        }
+        stopSteam();
     }
 
     // @formatter:off


### PR DESCRIPTION
This PR builds on #4. The `MediaStream.stop()` function is now deprecated. According to the [guidance here](https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en#stop-ended-and-active), I updated the `onUnload` to stop each of the underlying tracks.

I also exposed the ability for the client to stop the stream.